### PR TITLE
Add --as-rol-schema flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v1.5.0 (not released yet)
 
 * Removed `--limit` and `--step` command line flags
+* Add `--as-rol-schema` command line flag, which can output the table dump in
+  [Rule of Law](https://github.com/nvie/rule-of-law) compatible schema format
 
 
 # v1.4.1

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@babel/runtime": "^7.8.4",
     "commander": "^4.0.1",
     "invariant": "^2.2.4",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "rule-of-law": "^0.0.5"
   }
 }

--- a/src/sim/Database.js
+++ b/src/sim/Database.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 import { sortBy, zip } from 'lodash';
+import type { Schema as ROLSchema } from 'rule-of-law/types';
 
 import Column from './Column';
 import type { IndexType } from './Index';
@@ -263,6 +264,14 @@ export default class Database {
 
   dropIndex(tblName: string, indexName: string): Database {
     return this.swapTable(tblName, table => table.dropIndex(indexName));
+  }
+
+  toSchema(): ROLSchema {
+    const schema = {};
+    for (const table of this.getTables()) {
+      schema[table.name] = table.toSchema();
+    }
+    return schema;
   }
 
   // The optional subset of tables to print

--- a/src/sim/Table.js
+++ b/src/sim/Table.js
@@ -1,6 +1,8 @@
 // @flow strict
 
 import { maxBy, sortBy } from 'lodash';
+import t from 'rule-of-law/types';
+import type { RecordTypeInfo as ROLRecordTypeInfo } from 'rule-of-law/types';
 
 import Column from './Column';
 import Database from './Database';
@@ -557,6 +559,22 @@ export default class Table {
       ...this.getFullTextIndexes().map(index => index.toString()),
       ...this.getForeignKeys().map(fk => fk.toString()),
     ];
+  }
+
+  toSchema(): ROLRecordTypeInfo {
+    const record = {};
+    for (const col of this.columns) {
+      try {
+        record[col.name] = col.toSchema();
+      } catch (e) {
+        if (/Not yet supported/.test(e.message)) {
+          // Just skip it for now
+        } else {
+          throw e;
+        }
+      }
+    }
+    return t.Record(record, this.name);
   }
 
   toString(): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,7 +739,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-flow-strip-types" "^7.8.3"
 
-"@babel/runtime@^7.8.4":
+"@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
@@ -1859,7 +1859,7 @@ colordiff@1.0.4:
     colors "^1.0.3"
     through2 "^0.6.5"
 
-colors@^1.0.3, colors@^1.3.2:
+colors@^1.0.3, colors@^1.3.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -1876,7 +1876,7 @@ commander@^2.11.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1:
+commander@^4.0.1, commander@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -5106,6 +5106,16 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+rule-of-law@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/rule-of-law/-/rule-of-law-0.0.5.tgz#748eceb595c147657a431733f02b943e5ba5f71e"
+  integrity sha512-PLJ9jQL16UBCaZEItJzvO7BJ4RrasRsKHNGFFi0li4tKSrJWA4Tuc21MGghu49rnDNMBmU4+2nnW7qgHUXiUkg==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    colors "^1.4.0"
+    commander "^4.1.0"
+    invariant "^2.2.4"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Normally, when using the `mysql-simulate` command line, like so:

```
$ mysql-simulate migrations/

CREATE TABLE `addresses` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `user_id` int(11) NOT NULL,
  `street_line_1` varchar(256) NOT NULL,
  `street_line_2` varchar(256) DEFAULT NULL,
  `city` varchar(128) NOT NULL,
  ...
```

The output will be a SQL dump of the database.

By using the new `--as-rol-schema` flag, this will instead output the dump as a Rule of Law compatible schema format:

```
$ mysql-simulate --as-rol-schema migrations/
{
  "addresses": {
    "id": "Int",
    "user_id": "Int",
    "street_line_1": "String",
    "street_line_2": "String?",
    "city": "String",
    ...
```

This will make integrating the sanity checker a breeze, and hook it up with codegen in the simplest way, where our helper tools aren't aware of each other, and are very loosely coupled with only this shared schema file sitting in between them.
